### PR TITLE
Replace interface template with ip/ipconfig script

### DIFF
--- a/src/go/tmpl/templates/linux_interfaces.tmpl
+++ b/src/go/tmpl/templates/linux_interfaces.tmpl
@@ -1,56 +1,33 @@
-{{ if eq .Hardware.OSType "linux" }}
-auto lo
-iface lo inet loopback
+#!/usr/bin/env bash
+
+# Stop NetworkManager from configuring interfaces and overwriting these settings
+service NetworkManager stop
+
+# Check if ip command exists
+if command -v 'ip' &>/dev/null; then
     {{ range $idx, $iface := .Network.Interfaces }}
-auto eth{{ $idx }}
-allow-hotplug eth{{ $idx }}
-        {{ if eq $iface.Address "" }}
-iface eth{{ $idx }} inet manual
-        {{ else if eq $iface.Proto "dhcp" }}
-iface eth{{ $idx }} inet dhcp
-        {{ else }}
-iface eth{{ $idx }} inet static
-address {{ $iface.Address }}
-netmask {{ $iface.NetworkMask }}
+        {{ if ne $iface.Proto "dhcp" }}
+    dev=$(ip -oneline -4 link show | grep -iv 'LOOPBACK' | awk 'NR=={{ addInt $idx 1 }} {split($2, devname, ":"); print devname[1]}')
+    ip link set dev "$dev" down
+    ip addr flush dev "$dev"
+    ip addr add {{ $iface.Address }}/{{ $iface.Mask }} dev "$dev"
+    ip link set dev "$dev" up
             {{ if ne $iface.Gateway "" }}
-gateway {{ $iface.Gateway }}
+    ip route add default via {{ $iface.Gateway }} dev "$dev"
             {{ end }}
         {{ end }}
     {{ end }}
+else
+    # Fallback to ifconfig
     {{ range $idx, $iface := .Network.Interfaces }}
-auto ens{{ addInt $idx 1 }}
-allow-hotplug ens{{ addInt $idx 1 }}
-        {{ if eq $iface.Address "" }}
-iface ens{{ addInt $idx 1 }} inet manual
-        {{ else if eq $iface.Proto "dhcp" }}
-iface ens{{ addInt $idx 1 }} inet dhcp
-        {{ else }}
-iface ens{{ addInt $idx 1 }} inet static
-address {{ $iface.Address }}
-netmask {{ $iface.NetworkMask }}
+        {{ if ne $iface.Proto "dhcp" }}
+    dev=$(ifconfig -s -a | grep -ivE '^lo|Iface' | awk 'NR=={{ addInt $idx 1 }} { print $1 }')
+    ifconfig "$dev" down
+    ifconfig "$dev" {{ $iface.Address }} netmask {{ cidrToMask (print $iface.Address "/" $iface.Mask) }}
+    ifconfig "$dev" up
             {{ if ne $iface.Gateway "" }}
-gateway {{ $iface.Gateway }}
+    route add default gw {{ $iface.Gateway }} dev "$dev"
             {{ end }}
         {{ end }}
     {{ end }}
-{{ else if eq .Hardware.OSType "centos" }}
-    {{ range $idx, $iface := .Network.Interfaces }}   
-DEVICE=eth{{ $idx }}
-        {{ if eq $iface.Proto "dhcp" }}
-BOOTPROTO=dhcp
-ONBOOT=yes
-        {{ else if eq $iface.Address ""}}
-BOOTPROTO=none
-ONBOOT=yes
-        {{ else }}
-BOOTPROTO=none
-ONBOOT=yes
-IPADDR={{ $iface.Address }}
-NETMASK={{ $iface.NetworkMask }}
-            {{ if ne $iface.Gateway "" }}
-GATEWAY={{ $iface.Gateway }}
-            {{ end }}
-USERCTL=none
-        {{ end }}
-    {{ end }}
-{{ end }}
+fi

--- a/src/go/tmpl/tmpl.go
+++ b/src/go/tmpl/tmpl.go
@@ -3,6 +3,7 @@ package tmpl
 import (
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -25,6 +26,14 @@ func GenerateFromTemplate(name string, data interface{}, w io.Writer) error {
 			}
 
 			return *b
+		},
+		"cidrToMask": func(a string) string {
+			_, ipv4Net, _ := net.ParseCIDR(a)
+
+			// CIDR to four byte mask
+			mask := ipv4Net.Mask
+
+			return fmt.Sprintf("%d.%d.%d.%d", mask[0], mask[1], mask[2], mask[3])
 		},
 	}
 


### PR DESCRIPTION
Make interfaces template more robust by replacing interface file template with a script using ip or ipconfig commands.

Resolves #23 

@activeshadow Tested on Ubuntu 18.04, but it should work for any *nix that has `ip` or `ifconfig` command. Note this puts the interfaces script into `/etc/phenix/startup/...`, so there's probably a better method so users aren't required to have the `phenix-startup` service baked in. Maybe this will all be a moot point when miniccc is more tightly ingrained and we can just call the `ip` or `ifconfig` commands using cc.