### PR TITLE
Fixes issue 13 with do not boot flag

### DIFF
--- a/src/go/api/vm/vm.go
+++ b/src/go/api/vm/vm.go
@@ -157,6 +157,7 @@ func Get(expName, vmName string) (*mm.VM, error) {
 			RAM:        node.Hardware().Memory(),
 			Disk:       node.Hardware().Drives()[0].Image(),
 			Interfaces: make(map[string]string),
+			DoNotBoot:  *node.General().DoNotBoot(),
 			OSType:     string(node.Hardware().OSType()),
 			Metadata:   make(map[string]interface{}),
 		}

--- a/src/js/src/components/StoppedExperiment.vue
+++ b/src/js/src/components/StoppedExperiment.vue
@@ -308,7 +308,7 @@
 
       bootDecorator ( dnb ) {
         if ( dnb ) {
-          return '';
+          return 'dnb';
         } else {
           return 'boot';
         }
@@ -381,7 +381,7 @@
       },
       
       updateExperiment () {
-        this.$http.get( 'experiments/' + this.$route.params.id ).then(
+        this.$http.get( 'experiments/' + this.$route.params.id + '?show_dnb=true').then(
           response => {
             response.json().then( state => {
               this.experiment = state;
@@ -958,6 +958,10 @@
   
   svg.fa-bolt.boot {
     color: #c46200;
+  }
+
+  svg.fa-bolt.dnb {
+    color: #ffffff;
   }
 
   div.autocomplete >>> a.dropdown-item {


### PR DESCRIPTION
This fix should address the following items mentioned in issue activeshadow/phenix#13

1. VMs set to do not boot should show up in the experiment VM list in the stopped state.
2. The lighting bolt is orange when the VM is set to boot. When the VM is set to not boot, the lighting bolt will be white. The added "dnb" class is not really needed as the default color is white. On the other hand, the "dnb" class makes it easy to adjust the color scheme in the future


