### PR TITLE
Fixes issue 25 with web UI visual capture state

### DIFF
--- a/src/go/api/vm/vm.go
+++ b/src/go/api/vm/vm.go
@@ -88,7 +88,8 @@ func List(expName string) ([]mm.VM, error) {
 			vm.Host = details.Host
 			vm.Running = details.Running
 			vm.Networks = details.Networks
-			vm.Taps = details.Taps
+			vm.Taps = details.Taps	
+			vm.Captures = details.Captures
 			vm.Uptime = details.Uptime
 			vm.CPUs = details.CPUs
 			vm.RAM = details.RAM
@@ -195,7 +196,8 @@ func Get(expName, vmName string) (*mm.VM, error) {
 	vm.Host = details[0].Host
 	vm.Running = details[0].Running
 	vm.Networks = details[0].Networks
-	vm.Taps = details[0].Taps
+	vm.Taps = details[0].Taps	
+	vm.Captures = details[0].Captures
 	vm.Uptime = details[0].Uptime
 	vm.CPUs = details[0].CPUs
 	vm.RAM = details[0].RAM

--- a/src/go/internal/mm/minimega.go
+++ b/src/go/internal/mm/minimega.go
@@ -150,8 +150,10 @@ func (this Minimega) GetVMInfo(opts ...Option) VMs {
 			vm.Taps = strings.Split(s, ", ")
 		}
 
-		vm.Captures = this.GetVMCaptures(opts...)
-
+		// Make sure the VM name is set prior to calling `GetVMCaptures`, as the VM
+		// name is not always set when calling `GetVMInfo`.
+		vm.Captures = this.GetVMCaptures(NS(o.ns), VMName(vm.Name))
+		
 		uptime, err := time.ParseDuration(row["uptime"])
 		if err == nil {
 			vm.Uptime = uptime.Seconds()


### PR DESCRIPTION
The captures array in RunningExperiment.vue was getting blown away when the client would ask for a new list of VMs (e.g. call to updateTable when searching, sorting, changing pages, or page refreshes). The solution was to make sure that VM captures are returned with VM list requests from the client.