### PR TITLE
Don't let app failures prevent experiment from being stopped

### DIFF
--- a/src/go/app/app.go
+++ b/src/go/app/app.go
@@ -157,7 +157,7 @@ func ApplyApps(ctx context.Context, exp *types.Experiment, opts ...Option) error
 		err     error
 	)
 
-	if options.Stage == ACTIONPOSTSTART || options.Stage == ACTIONCLEANUP {
+	if options.Stage == ACTIONPOSTSTART {
 		// Reset status.apps for experiment. Note that this will get rid of any app
 		// status from previous experiment deployments.
 		exp.Status.ResetAppStatus()

--- a/src/go/cmd/experiment.go
+++ b/src/go/cmd/experiment.go
@@ -419,7 +419,7 @@ func newExperimentStopCmd() *cobra.Command {
 				}
 
 				if err := experiment.Stop(exp.Metadata.Name); err != nil {
-					err := util.HumanizeError(err, "Unable to stop the "+exp.Metadata.Name+" experiment")
+					err := util.HumanizeError(err, "Problem encountered while stopping the "+exp.Metadata.Name+" experiment")
 					return err.Humanized()
 				}
 


### PR DESCRIPTION
Currently if an app fails in the cleanup stage the experiment will not be cleared and marked as stopped. Also, if clearing the minimega namespace fails the experiment will not be marked as stopped.

This PR modifies the experiment stop function to mark the experiment as stopped no matter what and log any problems encountered while stopping the experiment so the user can manually clean things up if needed.